### PR TITLE
Feature/Peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go get https://github.com/chermehdi/eunomia
 - This is the simplest possible example:
 
 ```go
-queue := eunomia.NewQueue("queue-name")
+queue := eunomia.NewQueue("queue-name", serializer)
 queue.Add(serializableStruct)
 queue.Add(serializableStruct)
 
@@ -26,9 +26,9 @@ queueLength := queue.Size() // 1
 queue.Delete() // dangerous, will delete the file
 ```
 
-- The only constraint on your data is that it should adhere to the `QueueElement` interface, which simply tells
-the queue implementation how to serialize your data from and to a byte stream.
-
+- Each queue is associated with 1 datatype, and should be provided a `Serializer` instance, an element that knows how
+to convert your data type to/from a `[]byte`.
+ 
 ## How Eunomia stores data?
 
 ### Serialisation format

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,106 @@
+package eunomia
+
+import "os"
+
+func WriteInt(file *os.File, offset int64, value int32) error {
+	buffer[0] = byte(value >> 24)
+	buffer[1] = byte(value >> 16)
+	buffer[2] = byte(value >> 8)
+	buffer[3] = byte(value)
+	written, err := file.WriteAt(buffer[0:4], offset)
+	if err != nil {
+		return err
+	}
+	if written != 4 {
+		return UnexpectedNumberOfWrittenBytesError
+	}
+	return nil
+}
+
+// Write an int64 value in the given offset of the file.
+// If the value cannot be written to the file an error is returned.
+func WriteLong(file *os.File, offset int64, value int64) error {
+	buffer[0] = byte(value >> 56)
+	buffer[1] = byte(value >> 48)
+	buffer[2] = byte(value >> 40)
+	buffer[3] = byte(value >> 32)
+	buffer[4] = byte(value >> 24)
+	buffer[5] = byte(value >> 16)
+	buffer[6] = byte(value >> 8)
+	buffer[7] = byte(value)
+	written, err := file.WriteAt(buffer[0:8], offset)
+	if err != nil {
+		return err
+	}
+	if written != 8 {
+		return UnexpectedNumberOfWrittenBytesError
+	}
+	return nil
+}
+
+func ReadInt(file *os.File, offset int64) (int32, error) {
+	buffer, err := ReadChunk(file, offset, 4)
+	if err != nil {
+		return -1, err
+	}
+	result := (int32(buffer[0]&0xff) << 24) + (int32(buffer[1]&0xff) << 16) + (int32(buffer[2]&0xff) << 8) + int32(buffer[3])
+	return result, nil
+}
+
+func ReadLong(file *os.File, offset int64) (int64, error) {
+	buffer, err := ReadChunk(file, offset, 8)
+	if err != nil {
+		return -1, err
+	}
+	result := (int64(buffer[0]&0xff) << 56) + (int64(buffer[1]&0xff) << 48) + (int64(buffer[2]&0xff) << 40) + (int64(buffer[3]) << 32) + (int64(buffer[4]) << 24) + (int64(buffer[5]) << 16) + (int64(buffer[6]) << 8) + (int64(buffer[7]))
+	return result, nil
+}
+
+func ReadChunk(file *os.File, offset, length int64) ([]byte, error) {
+	buffer := make([]byte, length)
+	_, err := file.ReadAt(buffer, offset)
+	if err != nil {
+		return nil, err
+	}
+	return buffer, nil
+}
+
+func WriteChunk(file *os.File, offset int64, data []byte) (int, error) {
+	written, err := file.WriteAt(data, offset)
+	if err != nil {
+		return -1, err
+	}
+	return written, nil
+}
+
+// Writes the passed header as specified by the protocol description to the
+// queue file. If an error occurs during writing and error is returned.
+func writeHeader(file *os.File, header *header) error {
+	currentOffset := int64(0)
+	err := WriteInt(file, currentOffset, header.version)
+	currentOffset += 4
+	if err != nil {
+		return err
+	}
+	err = WriteInt(file, currentOffset, header.flags)
+	currentOffset += 4
+	if err != nil {
+		return err
+	}
+	err = WriteLong(file, currentOffset, header.elementCount)
+	currentOffset += 8
+	if err != nil {
+		return err
+	}
+	err = WriteLong(file, currentOffset, header.head.offset)
+	currentOffset += 8
+	if err != nil {
+		return err
+	}
+	err = WriteLong(file, currentOffset, header.tail.offset)
+	currentOffset += 8
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/encoding.go
+++ b/encoding.go
@@ -1,8 +1,11 @@
 package eunomia
 
-import "os"
+import (
+	"io"
+)
 
-func WriteInt(file *os.File, offset int64, value int32) error {
+// Write an int32 at the given offset.
+func WriteInt(file io.WriterAt, offset int64, value int32) error {
 	buffer[0] = byte(value >> 24)
 	buffer[1] = byte(value >> 16)
 	buffer[2] = byte(value >> 8)
@@ -19,7 +22,7 @@ func WriteInt(file *os.File, offset int64, value int32) error {
 
 // Write an int64 value in the given offset of the file.
 // If the value cannot be written to the file an error is returned.
-func WriteLong(file *os.File, offset int64, value int64) error {
+func WriteLong(file io.WriterAt, offset int64, value int64) error {
 	buffer[0] = byte(value >> 56)
 	buffer[1] = byte(value >> 48)
 	buffer[2] = byte(value >> 40)
@@ -38,7 +41,8 @@ func WriteLong(file *os.File, offset int64, value int64) error {
 	return nil
 }
 
-func ReadInt(file *os.File, offset int64) (int32, error) {
+// Read an int32 at the given offset
+func ReadInt(file io.ReaderAt, offset int64) (int32, error) {
 	buffer, err := ReadChunk(file, offset, 4)
 	if err != nil {
 		return -1, err
@@ -47,7 +51,8 @@ func ReadInt(file *os.File, offset int64) (int32, error) {
 	return result, nil
 }
 
-func ReadLong(file *os.File, offset int64) (int64, error) {
+// Read an int64 at the given offset
+func ReadLong(file io.ReaderAt, offset int64) (int64, error) {
 	buffer, err := ReadChunk(file, offset, 8)
 	if err != nil {
 		return -1, err
@@ -56,7 +61,8 @@ func ReadLong(file *os.File, offset int64) (int64, error) {
 	return result, nil
 }
 
-func ReadChunk(file *os.File, offset, length int64) ([]byte, error) {
+// Read a chunk of data starting at the given offset and ending at offset + length - 1.
+func ReadChunk(file io.ReaderAt, offset, length int64) ([]byte, error) {
 	buffer := make([]byte, length)
 	_, err := file.ReadAt(buffer, offset)
 	if err != nil {
@@ -65,7 +71,9 @@ func ReadChunk(file *os.File, offset, length int64) ([]byte, error) {
 	return buffer, nil
 }
 
-func WriteChunk(file *os.File, offset int64, data []byte) (int, error) {
+// Write the given chunk o data at the given offset.
+// If the data couldn't be written as a whole, an error is raised.
+func WriteChunk(file io.WriterAt, offset int64, data []byte) (int, error) {
 	written, err := file.WriteAt(data, offset)
 	if err != nil {
 		return -1, err
@@ -75,7 +83,7 @@ func WriteChunk(file *os.File, offset int64, data []byte) (int, error) {
 
 // Writes the passed header as specified by the protocol description to the
 // queue file. If an error occurs during writing and error is returned.
-func writeHeader(file *os.File, header *header) error {
+func writeHeader(file io.WriterAt, header *header) error {
 	currentOffset := int64(0)
 	err := WriteInt(file, currentOffset, header.version)
 	currentOffset += 4

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -9,27 +9,27 @@ func TestReadWriteInt(t *testing.T) {
 	queueFile := createTestFile()
 	defer deleteFile(queueFile)
 
-	assert.NoError(t, writeInt(queueFile, 0, 12))
-	assert.NoError(t, writeInt(queueFile, 4, 42))
-	assert.NoError(t, writeInt(queueFile, 8, -12))
-	assert.NoError(t, writeInt(queueFile, 12, int32(1)<<30))
+	assert.NoError(t, WriteInt(queueFile, 0, 12))
+	assert.NoError(t, WriteInt(queueFile, 4, 42))
+	assert.NoError(t, WriteInt(queueFile, 8, -12))
+	assert.NoError(t, WriteInt(queueFile, 12, int32(1)<<30))
 
 	fileInfo, _ := queueFile.Stat()
 	assert.Equal(t, int64(16), fileInfo.Size())
 
-	val, err := readInt(queueFile, 0)
+	val, err := ReadInt(queueFile, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(12), val)
 
-	val, err = readInt(queueFile, 4)
+	val, err = ReadInt(queueFile, 4)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(42), val)
 
-	val, err = readInt(queueFile, 8)
+	val, err = ReadInt(queueFile, 8)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(-12), val)
 
-	val, err = readInt(queueFile, 12)
+	val, err = ReadInt(queueFile, 12)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1)<<30, val)
 }
@@ -38,27 +38,27 @@ func TestReadWriteLong(t *testing.T) {
 	queueFile := createTestFile()
 	defer deleteFile(queueFile)
 
-	assert.NoError(t, writeLong(queueFile, 0, 12))
-	assert.NoError(t, writeLong(queueFile, 8, 42))
-	assert.NoError(t, writeLong(queueFile, 16, -12))
-	assert.NoError(t, writeLong(queueFile, 24, int64(1)<<60))
+	assert.NoError(t, WriteLong(queueFile, 0, 12))
+	assert.NoError(t, WriteLong(queueFile, 8, 42))
+	assert.NoError(t, WriteLong(queueFile, 16, -12))
+	assert.NoError(t, WriteLong(queueFile, 24, int64(1)<<60))
 
 	fileInfo, _ := queueFile.Stat()
 	assert.Equal(t, int64(32), fileInfo.Size())
 
-	val, err := readLong(queueFile, 0)
+	val, err := ReadLong(queueFile, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(12), val)
 
-	val, err = readLong(queueFile, 8)
+	val, err = ReadLong(queueFile, 8)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(42), val)
 
-	val, err = readLong(queueFile, 16)
+	val, err = ReadLong(queueFile, 16)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(-12), val)
 
-	val, err = readLong(queueFile, 24)
+	val, err = ReadLong(queueFile, 24)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1)<<60, val)
 }

--- a/queue.go
+++ b/queue.go
@@ -137,14 +137,6 @@ type QueueProtocolWriter struct {
 	header      *header
 }
 
-func (w *QueueProtocolWriter) updateTail(ptr *elementPtr) {
-	if w.header.head.index == 0 {
-		// First time
-		w.header.head.length = ptr.length
-	}
-	w.header.tail = ptr
-}
-
 // Pointer to some data element in the file
 // Each element is identified by it's start position and it's length (in bytes).
 // The elements are written [elementLength,elementData] and the offset points to the first
@@ -265,6 +257,14 @@ func checkCorrupt(file *os.File) (*header, error) {
 	header.tail = &elementPtr{
 		offset: tailOffset,
 		length: 0,
+	}
+	headLength, err := ReadLong(file, headOffset)
+	if err == nil {
+		header.head.length = headLength
+	}
+	tailLength, err := ReadLong(file, tailOffset)
+	if err == nil {
+		header.tail.length = tailLength
 	}
 	return header, nil
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -18,6 +18,27 @@ func TestNewQueueWriter(t *testing.T) {
 	assert.Equal(t, queueWriter.header.head.length, queueWriter.header.tail.length)
 }
 
+func TestNewFileQueue_FromExistingValidFile(t *testing.T) {
+	queue, err := NewFileQueue("queue-file", &MockDataSerializer{})
+	defer queue.Delete()
+
+	assert.NoError(t, err)
+
+	err = queue.Push(MockData{12})
+	assert.NoError(t, err)
+
+	newQueue, err := NewFileQueue("queue-file", &MockDataSerializer{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, newQueue.Size(), queue.Size())
+	fileQueue1 := queue.(*FileQueue)
+	fileQueue2 := newQueue.(*FileQueue)
+	assert.Equal(t, fileQueue1.writer.header.head.offset, fileQueue2.writer.header.head.offset)
+	assert.Equal(t, fileQueue1.writer.header.head.length, fileQueue2.writer.header.head.length)
+	assert.Equal(t, fileQueue1.writer.header.tail.offset, fileQueue2.writer.header.tail.offset)
+	assert.Equal(t, fileQueue1.writer.header.tail.length, fileQueue2.writer.header.tail.length)
+}
+
 func TestCheckCorrupt_WrongVersionNumber(t *testing.T) {
 	queueFile := createTestFile()
 	defer deleteFile(queueFile)

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,12 @@
+package eunomia
+
+import "os"
+
+// Returns true if the file does not exist, or empty
+func fileExist(file *os.File) bool {
+	info, err := os.Stat(file.Name())
+	if err != nil {
+		return os.IsExist(err)
+	}
+	return info.Size() > 0
+}


### PR DESCRIPTION
Add Pull support

Change constraints on the elements added to the queue, from implementing the `QueueElement` interface to letting the user decide by supplying a `Serializer` instance at queue construction time.