### PR TITLE
fix go module description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ even if your process crashes, allowing for safer workloads.
 
 - The usage is pretty straight forward you can start by doing 
 ```
-go get https://github.com/chermehdi/eunomia
+go get github.com/chermehdi/eunomia
 ```
 - This is the simplest possible example:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chrmehdi/eunomia
+module github.com/chermehdi/eunomia
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
I got some errors

1. seems to be a formatting error in [README](https://github.com/chermehdi/eunomia/blob/2e05b10843e1ad39bcae7719f116f1866567149c/README.md?plain=1#L12)
2. module name in go.mod seems to be [typo](https://github.com/chermehdi/eunomia/blob/2e05b10843e1ad39bcae7719f116f1866567149c/go.mod#L1)

each errors will be as below:

```
$ go get https://github.com/chermehdi/eunomia
go: malformed module path "https:/github.com/chermehdi/eunomia": invalid char ':'

$ go get github.com/chermehdi/eunomia
go: github.com/chermehdi/eunomia@v0.0.0-20200507225944-2e05b10843e1: parsing go.mod:
	module declares its path as: github.com/chrmehdi/eunomia
	        but was required as: github.com/chermehdi/eunomia
```